### PR TITLE
Connectivity: Use OpenDNS instead of Cloudflare DNS

### DIFF
--- a/Tethering/src/com/android/networkstack/tethering/TetheringConfiguration.java
+++ b/Tethering/src/com/android/networkstack/tethering/TetheringConfiguration.java
@@ -78,7 +78,7 @@ public class TetheringConfiguration {
         "192.168.48.2", "192.168.48.254", "192.168.49.2", "192.168.49.254",
     };
 
-    private static final String[] DEFAULT_IPV4_DNS = {"1.0.0.1", "1.1.1.1"};
+    private static final String[] DEFAULT_IPV4_DNS = {"149.112.112.112", "9.9.9.9"};
 
     @VisibleForTesting
     public static final int TETHER_USB_RNDIS_FUNCTION = 0;
@@ -746,4 +746,6 @@ public class TetheringConfiguration {
 
         return parcel;
     }
+}
+  }
 }

--- a/framework/src/android/net/util/DnsUtils.java
+++ b/framework/src/android/net/util/DnsUtils.java
@@ -342,7 +342,7 @@ public class DnsUtils {
      */
     public static boolean haveIpv4(@Nullable Network network) {
         final SocketAddress addrIpv4 =
-                new InetSocketAddress(InetAddresses.parseNumericAddress("1.1.1.1"), 0);
+                new InetSocketAddress(InetAddresses.parseNumericAddress("9.9.9.9"), 0);
         return checkConnectivity(network, AF_INET, addrIpv4);
     }
 
@@ -373,5 +373,7 @@ public class DnsUtils {
             IoUtils.closeQuietly(socket);
         }
         return true;
+    }
+}
     }
 }

--- a/service/src/com/android/server/connectivity/NetworkDiagnostics.java
+++ b/service/src/com/android/server/connectivity/NetworkDiagnostics.java
@@ -109,9 +109,9 @@ import javax.net.ssl.SSLSocketFactory;
 public class NetworkDiagnostics {
     private static final String TAG = "NetworkDiagnostics";
 
-    private static final InetAddress TEST_DNS4 = InetAddresses.parseNumericAddress("1.1.1.1");
+    private static final InetAddress TEST_DNS4 = InetAddresses.parseNumericAddress("9.9.9.9");
     private static final InetAddress TEST_DNS6 = InetAddresses.parseNumericAddress(
-            "2606:4700:4700::1111");
+            "2620:fe::fe");
 
     // For brevity elsewhere.
     private static final long now() {
@@ -852,5 +852,8 @@ public class NetworkDiagnostics {
                 mMeasurement.recordFailure(e.toString());
             }
         }
+    }
+}
+ }
     }
 }


### PR DESCRIPTION
Since cloudflare is slow in some countries, we use OpenDNS instead, since they have more servers